### PR TITLE
lowercase cosinewindowedsinc

### DIFF
--- a/Examples/make_interpolator_snip.tmpl
+++ b/Examples/make_interpolator_snip.tmpl
@@ -74,7 +74,7 @@ typename InterpolatorType::Pointer interpolator = ITK_NULLPTR;
     gaussianInterpolator->SetParameters( sigma, alpha );
     interpolator = gaussianInterpolator;
     }
-  else if( !std::strcmp( whichInterpolator.c_str(), "CosineWindowedSinc" ) )
+  else if( !std::strcmp( whichInterpolator.c_str(), "cosinewindowedsinc" ) )
     {
     typedef itk::WindowedSincInterpolateImageFunction
                  <ImageType, 3, itk::Function::CosineWindowFunction<3, RealType, RealType>, itk::ConstantBoundaryCondition< ImageType >, RealType> CosineInterpolatorType;


### PR DESCRIPTION
When running antsapplytransform the tool fails to recognise the option "cosinewindowedsinc". I am not sure if this will fix it but it might just as well help to keep things consistent